### PR TITLE
Adding a color field for links when hovering over them.

### DIFF
--- a/STARTERKIT/theme-settings.php
+++ b/STARTERKIT/theme-settings.php
@@ -33,6 +33,7 @@ if (module_exists('color')) {
     'bg',
     'text',
     'link',
+    'hover',
     'borders',
     'formfocusborder',
   );

--- a/color/color.inc
+++ b/color/color.inc
@@ -11,6 +11,7 @@ $info = array(
     'bg' => t('Main background'),
     'text' => t('Text color'),
     'link' => t('Link color'),
+    'hover' => t('Link hover color'),
     'borders' => t('Borders'),
     'formfocusborder' => t('Form element borders when selected'),
 
@@ -36,6 +37,7 @@ $info = array(
         'bg' => '#ffffff',
         'text' => '#000001',
         'link' => '#0073bd',
+        'hover' => '#bd0073',
         'borders' => '#bbbbbb',
         'formfocusborder' => '#43afe4',
 
@@ -60,6 +62,7 @@ $info = array(
         'bg' => '#ffffff',
         'text' => '#2a2a2a',
         'link' => '#00809c',
+        'hover' => '#9c0080',
         'borders' => '#24272c',
         'formfocusborder' => '#ffffff',
 
@@ -84,6 +87,7 @@ $info = array(
         'bg' => '#fffdf7',
         'text' => '#301313',
         'link' => '#9d408d',
+        'hover' => '#8d9d40',
         'borders' => '#2c2c28',
         'formfocusborder' => '#edede7',
 
@@ -108,6 +112,7 @@ $info = array(
         'bg' => '#ffffff',
         'text' => '#3b3b3b',
         'link' => '#fa6900',
+        'hover' => '#00fa69',
         'borders' => '#4c5036',
         'formfocusborder' => '#f3f4e9',
 
@@ -132,6 +137,7 @@ $info = array(
         'bg' => '#faf8f8',
         'text' => '#3b3738',
         'link' => '#c63d0f',
+        'hover' => '#0fc63d',
         'borders' => '#dec0b4',
         'formfocusborder' => '#ffffff',
 

--- a/css/skin.css
+++ b/css/skin.css
@@ -28,6 +28,10 @@ a {
   color: #0073bd;
 }
 
+a:hover {
+  color: #bd0073;
+}
+
 a:focus,
 a:hover {
   text-decoration: none;

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -33,6 +33,7 @@ if (module_exists('color')) {
     'bg',
     'text',
     'link',
+    'hover',
     'borders',
     'formfocusborder',
   );


### PR DESCRIPTION
Fixes #39

It is quite simple to add a color to the color page in order to change it in the UI.

This commit does so for the color of links when hovering over them.

Here are the steps:
- Make sure that whatever color you use is defined in somewhere in your CSS, and that the 6-digit color code you use is only defined for the item in question
- Modify your color.inc file as in this patch
- If you want it to show up in one of the fieldsets, modify the initial function in theme-settings.php like in the patch (I had to have @hosef show me this part)
- Update STARTERKIT, if desired

As a caveat, I made no effort to have the hover color fit the theme. I was more interested in having it contrast, so that it showed up well, and to that end, I simply coped the color code for links and moved the last two characters to the beginning, i.e., `#0073bd` became `#bd0073`.
