### PR TITLE
Fixes #64 - Page not found warning for themes/tatsu/images/add.png

### DIFF
--- a/css/skin.css
+++ b/css/skin.css
@@ -724,7 +724,7 @@ select.form-select[disabled] {
 }
 
 ul.action-links a {
-  background: transparent url(../images/add.png) no-repeat 0 center;
+  background-color: transparent;
   line-height: 1.875;
 }
 


### PR DESCRIPTION
Removed the CSS call to the missing image.

This fixes #64 