### PR TITLE
Fixes #65 - Need to remove border bottom from first item primary menu

### DIFF
--- a/css/basis-component-colors.css
+++ b/css/basis-component-colors.css
@@ -194,6 +194,13 @@ ul.action-links a:after {
   border: 1px solid #bbbbbb;
 }
 
+@media (min-width: 48em) {
+  .js .menu-dropdown li,
+  .js .menu-dropdown a.has-submenu.highlighted {
+    border-bottom: none;
+  }
+}
+
 /*  components/menu-toggle.css  */
 
 .menu-toggle-button-icon,


### PR DESCRIPTION
Added a media query to remove the border-bottom on large displays.  

This fixes #65 